### PR TITLE
Add $labelSteps to activity function

### DIFF
--- a/domainStory.puml
+++ b/domainStory.puml
@@ -235,7 +235,7 @@ skinparam note {
 !global $stepCounter = 0
 !global $objectCounter = 0
 
-!unquoted procedure activity($step, $subject, $predicate, $object, $post = "", $target = "", $objectArr = "", $targetArr = "", $color = "", $scale = "", $note = "")
+!unquoted procedure activity($step, $subject, $predicate, $object, $post = "", $target = "", $objectArr = "", $targetArr = "", $color = "", $scale = "", $note = "", $labelSteps = "")
     ' ensure object exists / create one dynamically
     !$object = $ensureObjectExists($object, $color, $scale)
 
@@ -258,7 +258,11 @@ skinparam note {
     !endif
 
     ' create connecting arrows
-    $arrow($subject, $object, $objectArr) : $stepLabel($step) $predicate
+    !if $labelSteps == ""
+        $arrow($subject, $object, $objectArr) : $stepLabel($step) $predicate
+    !else
+        $arrow($subject, $object, $objectArr) : $predicate
+    !endif
 
     !if $post != "" && $post != "_"
         !if $target != "" && $target != "_"

--- a/domainStory.puml
+++ b/domainStory.puml
@@ -235,7 +235,9 @@ skinparam note {
 !global $stepCounter = 0
 !global $objectCounter = 0
 
-!unquoted procedure activity($step, $subject, $predicate, $object, $post = "", $target = "", $objectArr = "", $targetArr = "", $color = "", $scale = "", $note = "", $labelSteps = "")
+!unquoted procedure activity($step, $subject, $predicate, $object, $post = "", $target = "", $objectArr = "", $targetArr = "", $color = "", $scale = "", $note = "", $labelSteps = "", $subjectColor = "", $subjectScale = "")
+    ' ensure subject exists / create one dynamically
+    !$subject = $ensureObjectExists($subject, $subjectColor, $subjectScale)
     ' ensure object exists / create one dynamically
     !$object = $ensureObjectExists($object, $color, $scale)
 


### PR DESCRIPTION
Sometimes, you want to connect nodes without having the nodes numbered.  (e.g., when a node starts a multistep process)

Adding `$labelSteps = "false"` to the activity function hides and doesn't increment the step number.

Closes #1.