### PR TITLE
Hide label step

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ If instead you pass a vertical bar `|`,
 the current step is declared as parallel to the last step,
 and the step counter won't be incremented.
 
+If you pass an exclamation mark `!`, the step spec will not be shown. 
+
 When you pass an integer value as step spec,
 the step label will be set to that value.
 If the integer is prefixed with an equal sign `=`,
@@ -214,6 +216,7 @@ the step counter will also be set to that value and auto-increment will continue
 activity(_, Bob, talks about the, weather) ' auto-increment, will create step 1
 activity(_, Bob, talks about the, weather) ' auto-increment, will create step 2
 activity(|, Bob, talks about the, weather) ' no increment, will create step 2
+activity(!, Bob, also talks about the, weather) /' will not create step, nor auto-increment, and will not display the step '/
 activity(42, Alice, asks about all the, talking, Bob) ' will create step 42
 activity(|, Bob, talks about the, weather) ' no increment, will create step 2
 activity(=10, Alice, asks about all the, talking, Bob) ' will create step 10

--- a/README.md
+++ b/README.md
@@ -213,14 +213,14 @@ If the integer is prefixed with an equal sign `=`,
 the step counter will also be set to that value and auto-increment will continue from there.
 
 ```puml
-activity(_, Bob, talks about the, weather) ' auto-increment, will create step 1
-activity(_, Bob, talks about the, weather) ' auto-increment, will create step 2
-activity(|, Bob, talks about the, weather) ' no increment, will create step 2
+activity(_, Bob, talks about the, weather) /' auto-increment, will create step 1 '/
+activity(_, Bob, talks about the, weather) /' auto-increment, will create step 2 '/
+activity(|, Bob, talks about the, weather) /' no increment, will create step 2 '/
 activity(!, Bob, also talks about the, weather) /' will not create step, nor auto-increment, and will not display the step '/
-activity(42, Alice, asks about all the, talking, Bob) ' will create step 42
-activity(|, Bob, talks about the, weather) ' no increment, will create step 2
-activity(=10, Alice, asks about all the, talking, Bob) ' will create step 10
-activity(_, Bob, is embarassed about, talking) ' auto-increment, will create step 11
+activity(42, Alice, asks about all the, talking, Bob) /' will create step 42 '/
+activity(|, Bob, talks about the, weather) /' no increment, will create step 2 '/
+activity(=10, Alice, asks about all the, talking, Bob) /' will create step 10 '/
+activity(_, Bob, is embarassed about, talking) /' auto-increment, will create step 11 '/
 ```
 
 ### Styling

--- a/domainStory.puml
+++ b/domainStory.puml
@@ -352,16 +352,21 @@ skinparam note {
 !endfunction
 
 !function $stepLabel($step)
-    !$stepNum = $computeStep($step)
-    !$result = "(" + $stepNum + ")"
-    !if ($stepColor != "")
-        !$result = "<back:" + $stepColor + ">" + $result + "</back>"
+   !$result = ""
+
+   !if $step != "!"
+        !$stepNum = $computeStep($step)
+        !$result = "(" + $stepNum + ")"
+        !if ($stepColor != "")
+            !$result = "<back:" + $stepColor + ">" + $result + "</back>"
+        !endif
+        !if ($stepFontColor != "")
+            !$result = "<color:" + $stepFontColor + ">" + $result + "</color>"
+        !endif
+        !if ($stepFontSize != "")
+            !$result = "<size:" + $stepFontSize + ">" + $result + "</size>"
+        !endif
     !endif
-    !if ($stepFontColor != "")
-        !$result = "<color:" + $stepFontColor + ">" + $result + "</color>"
-    !endif
-    !if ($stepFontSize != "")
-        !$result = "<size:" + $stepFontSize + ">" + $result + "</size>"
-    !endif
+
     !return $result
 !endfunction


### PR DESCRIPTION
As discussed in #5, it might be useful to be able to hide the step label.

This MR makes it possible to hide a step label for an activity by using `!` as `$step` parameter.

For instance, using this diagram:

```plantuml
@startuml
!include https://raw.githubusercontent.com/johthor/DomainStory-PlantUML/main/domainStory.puml

!include <material/crop>
!include <material/google_circles_communities>
!include <material/account_card_details>

skinparam WrapWidth 100

Actor("Document", "$ma_account_card_details", story.1, "AS-IS domain story")
Actor("Document", "$ma_account_card_details", story.2, "TO-BE domain story")
Actor("Document", "$ma_account_card_details", story.3, "AS-IS domain story")
Actor("Document", "$ma_account_card_details", story.4, "TO-BE domain story")
Actor("Person", "$ma_crop", change.1, "change")
Actor("Person", "$ma_crop", change.2, "change")
Actor("System", $ma_google_circles_communities, color)

Person(agent, "change agent")
Person(expert, "domain expert")
Group(experts, "other domain experts")

activity(_, agent, models, story.1)
activity(!, story.1, and, story.2)
activity(!, story.2, with, expert)

activity(_, agent, visualizes, change.1)
activity(!, change.1, with, color)
activity(!, color, in, story.3)
activity(!, story.3, with, story.4)

activity(_, agent, teaches, change.2)
activity(!, change.2, to, experts)
@enduml
```

| Current Situation | With the label step hidden |
|--- |--- |
| [![][1]][2] | [![][3]][4] |

Of course, a different character than `!` could be used if so desired. (Or even a word, like `__HIDE__`)

This MR also fixes the step label example, as using single quotes for comments somehow breaks the diagram:

[![][5]][6]

[1]: https://www.plantuml.com/plantuml/png/hP9FYzH04CNl-HIzWuSPc9di7qyYiYih8YWkHDbZA3j5khMxArHNxpf-UZkJRC90H96z9U_zUFMdwpeAi2JlYZCRj4iDAYFInLTboV2uRwsOz2r5P4r1CCXUao-_an53NDwI1nig8JxixXm4-VhfOzbBPJCx-wvFd-DVUn1a2wxKJDsR9QCbQXtMsh9s6EjSqgTWnM9Sn45hIa5g3TpK3GfOby4Y_h2X0mQlxXcwUzk8KHVdvqLneuLulRebdJm6MMtLweM7UYacU_4un4M6RghTXqeDemtoQlDVOPSP-l9vz_RTSuHTFMTdB__IsHrofF0KrJzW_jO6Gel75GsV_yPVBl3L8GhwpFJudyyWPv0ZtXJ5K60DBGQPyjJnDwUEBlxia7jx76hup_vxfjIDTim-YK5M9rJCM05Qx8ELmxhUgh6KfmPTdCvZCpDdavZXq4oFleJa7JnQCTkns7Af1niJEFiBuxphax197TAcxSp8A6sL3TFTBFLpDIHCvx3Sa21eCtTpEjgiPf2U9ekRuXf3axpx3G00

[2]: https://www.plantuml.com/plantuml/uml/hP9FYzH04CNl-HIzWuSPc9di7qyYiYih8YWkHDbZA3j5khMxArHNxpf-UZkJRC90H96z9U_zUFMdwpeAi2JlYZCRj4iDAYFInLTboV2uRwsOz2r5P4r1CCXUao-_an53NDwI1nig8JxixXm4-VhfOzbBPJCx-wvFd-DVUn1a2wxKJDsR9QCbQXtMsh9s6EjSqgTWnM9Sn45hIa5g3TpK3GfOby4Y_h2X0mQlxXcwUzk8KHVdvqLneuLulRebdJm6MMtLweM7UYacU_4un4M6RghTXqeDemtoQlDVOPSP-l9vz_RTSuHTFMTdB__IsHrofF0KrJzW_jO6Gel75GsV_yPVBl3L8GhwpFJudyyWPv0ZtXJ5K60DBGQPyjJnDwUEBlxia7jx76hup_vxfjIDTim-YK5M9rJCM05Qx8ELmxhUgh6KfmPTdCvZCpDdavZXq4oFleJa7JnQCTkns7Af1niJEFiBuxphax197TAcxSp8A6sL3TFTBFLpDIHCvx3Sa21eCtTpEjgiPf2U9ekRuXf3axpx3G00

[3]: https://www.plantuml.com/plantuml/png/hL9TQzH057tFhvWkFcnWi-c7JoBIIaK4nS8gVGntPwx9nVaOPkwqhh_UoIPDh4IKqhUPUmxddFjn6Ha29wEB4x9I9uMYO_RnLLq7kD-sn5tQfuX1EijeUIkTgRtZBbUWwek1zlMrCq1snouSgXiDbhz--bX_G-0KiEv8OQLXZxgAZBvMCtdhU-VP-hK1na2WQncSVxC4jCwr6Xj9GMgCJOvZaYKcZ8jqaD8bous4e1g53AGpiOZVoNe8OCHj07zBYZjnTdfQ55SovrglhfrC1YslDcBrma2p99EnU6pYB9EkTjM7dHXQ6yghyabYvvdqvNFrzjrpY5qyPxAN_qXsWo4w-o3LBp2_PGUsnUE8XkV_ySyN-Bj3P3IPqzF_VWPPmsaNog8e1eSrj6Xv4XJ7RvOTKVpXCVJmsDNmp_Zxu98VuPZnuz6BHwouwcr0CjqH7zRDHenUnYdKSJgGSkQS_7OrODMqzYLAdi8zSRSPtSf5gpkA2JJzn3XF-v7OL1tKfldCbB6q4MIdordASp4eJ0Un78WHP3Ud-RErUSFi7ZgBPN69LYMZVm40

[4]: https://www.plantuml.com/plantuml/uml/hL9TQzH057tFhvWkFcnWi-c7JoBIIaK4nS8gVGntPwx9nVaOPkwqhh_UoIPDh4IKqhUPUmxddFjn6Ha29wEB4x9I9uMYO_RnLLq7kD-sn5tQfuX1EijeUIkTgRtZBbUWwek1zlMrCq1snouSgXiDbhz--bX_G-0KiEv8OQLXZxgAZBvMCtdhU-VP-hK1na2WQncSVxC4jCwr6Xj9GMgCJOvZaYKcZ8jqaD8bous4e1g53AGpiOZVoNe8OCHj07zBYZjnTdfQ55SovrglhfrC1YslDcBrma2p99EnU6pYB9EkTjM7dHXQ6yghyabYvvdqvNFrzjrpY5qyPxAN_qXsWo4w-o3LBp2_PGUsnUE8XkV_ySyN-Bj3P3IPqzF_VWPPmsaNog8e1eSrj6Xv4XJ7RvOTKVpXCVJmsDNmp_Zxu98VuPZnuz6BHwouwcr0CjqH7zRDHenUnYdKSJgGSkQS_7OrODMqzYLAdi8zSRSPtSf5gpkA2JJzn3XF-v7OL1tKfldCbB6q4MIdordASp4eJ0Un78WHP3Ud-RErUSFi7ZgBPN69LYMZVm40

[5]: https://github.com/user-attachments/assets/04c2c383-c68a-4251-a18a-aebdf8139553

[6]: https://www.plantuml.com/plantuml/uml/jTB1IWCn40RW-px5zAJ2TjCjFGb25OyAWdYMsTsX6vrabcHYAVZmPgsqXruMR4yX6VZ-FoJhg1WqEIvcrhUSEe9UTOYtnWJSLXkhVMfIfD2AL_9QjUBCX_JQIp2Fuj3wLvMmcxymUdrxVZBZaUcEaseOzG9RjLzMTzVl9Jn8Ku8YVqR0HfA2zbJ2bZ2luGQk09FAFFS9vCXh7bbco3jKWgWqG7rcRtdqlYTuNc2YDllJaAESYLmjIxXdsr9Muy53vhqvXbY_-StDy2crkjXbx-h5_whLYzDtjH78DHWmHkhsua6QzbVgOas-Iuv_0000