### PR TITLE
Adjust icon sprite includes to new material versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  
 ### Added
 
-- Add version table and mention breaking changes in README
+- Add a version table and mention breaking changes in README
   ([#24](https://github.com/johthor/DomainStory-PlantUML/pull/24)), ([@johthor][gh-johthor])
 - Add automated snapshot test with [Sharness](https://felipec.github.io/sharness/)
   ([#25](https://github.com/johthor/DomainStory-PlantUML/pull/25)), ([@johthor][gh-johthor])
@@ -30,10 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#25](https://github.com/johthor/DomainStory-PlantUML/pull/25)), ([@johthor][gh-johthor])
 - Fix styling of boundary titles if combined with a boundary note
   ([#25](https://github.com/johthor/DomainStory-PlantUML/pull/25)), ([@johthor][gh-johthor])
+- Include the material icon sprites library with its major version
+  ([#28](https://github.com/johthor/DomainStory-PlantUML/pull/28)), ([@johthor][gh-johthor])
 
 ## Delta [0.4.0] - 2024-11-30
 
-The library now supports the build-in PlantUML themes
+The library now supports the built-in PlantUML themes
 and won't set any colors if a theme declaration is discovered.
 This leads to a complete rewrite of the styling declarations
 and extending the concept for multi-level declarations.

--- a/domainStory.puml
+++ b/domainStory.puml
@@ -187,6 +187,19 @@
     $declareStyleProperty($fallbackValue, $property, $element, $fallbackValue, $kind, "", $themeable, $skinParam)
 !endprocedure
 
+!procedure $includeIcon($name, $library = "material")
+    !if $library == "material"
+        !$stdLibsDetails = %get_all_stdlib(true)
+        !if %json_key_exists($stdLibsDetails, "material2")
+            !$library = "material2"
+        !elseif %json_key_exists($stdLibsDetails, "material2.1.19")
+            !$library = "material2.1.19"
+        !endif
+    !endif
+
+    !include <$library/$name>
+!endprocedure
+
 !procedure $extendStyleDeclarations($element, $kind, $icon)
     $extendStyleProperty(Shape, $element, $kind, $themeable = %false(), $skinParam = %false())
     $extendStyleProperty(IconScale, $element, $kind, $themeable = %false(), $skinParam = %false())
@@ -195,7 +208,7 @@
     !$variableName = $decideVariableName($kind, "", "IconName")
     !if $icon
         !if %not(%variable_exists($variableName))
-            !include <material/$icon>
+            $includeIcon($icon)
             %set_variable_value($variableName, "$ma_" + $icon)
         !endif
     !else

--- a/src/styling.iuml
+++ b/src/styling.iuml
@@ -146,6 +146,19 @@
     $declareStyleProperty($fallbackValue, $property, $element, $fallbackValue, $kind, "", $themeable, $skinParam)
 !endprocedure
 
+!procedure $includeIcon($name, $library = "material")
+    !if $library == "material"
+        !$stdLibsDetails = %get_all_stdlib(true)
+        !if %json_key_exists($stdLibsDetails, "material2")
+            !$library = "material2"
+        !elseif %json_key_exists($stdLibsDetails, "material2.1.19")
+            !$library = "material2.1.19"
+        !endif
+    !endif
+
+    !include <$library/$name>
+!endprocedure
+
 !procedure $extendStyleDeclarations($element, $kind, $icon)
     $extendStyleProperty(Shape, $element, $kind, $themeable = %false(), $skinParam = %false())
     $extendStyleProperty(IconScale, $element, $kind, $themeable = %false(), $skinParam = %false())
@@ -154,7 +167,7 @@
     !$variableName = $decideVariableName($kind, "", "IconName")
     !if $icon
         !if %not(%variable_exists($variableName))
-            !include <material/$icon>
+            $includeIcon($icon)
             %set_variable_value($variableName, "$ma_" + $icon)
         !endif
     !else


### PR DESCRIPTION
These changes take the available versions of the material standard lib into account when including the sprites.

Issue: #27